### PR TITLE
Tell git to ignore these files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+node_modules/
+
+package-lock.json


### PR DESCRIPTION
The `.gitignore` file is a list of file patterns that Git will look at: Git will ignore (not track) any file(s) matching these patterns.

We don't want git to track (version) the `node_modules/` directory because it contains lots of files that we didn't write and which we can easily regenerate by running `npm i`.

You can read more about `.gitignore` here:

* [Ignoring Files and Folders](https://medium.com/@haydar_ai/learning-how-to-git-ignoring-files-and-folders-using-gitignore-177556afdbe3)